### PR TITLE
Extend with Space issue

### DIFF
--- a/pseudoloc.js
+++ b/pseudoloc.js
@@ -66,7 +66,9 @@ pseudoloc = function() {
   pseudoloc.pad = function(str, percent) {
     var len = Math.floor(str.length * percent), pStr = str;
     while (len--) {
-      pStr += " ";
+      var array = [ 'ö', '🐔', 'ఛ', 'ฒ', ' ', 'そ', '開', 'अ', '㤌', 'కె'];
+      var tot = Math.floor(Math.random() * 10)
+      pStr += array[tot];
     }
     return pStr;
   };


### PR DESCRIPTION
Hi @bunkat 

The pseudoloc library uses 'white space' to extend the width of the string by the specified percentage.
The change which i made will use exotic asian characters including emoji instead of space.

This will solve the issue with spaces, as they are displayed as a single space in HTML.
Please let me know if you have any query.

Thank you,
John